### PR TITLE
Add conversions for java 8 time objects

### DIFF
--- a/src/mongrove/conversion.clj
+++ b/src/mongrove/conversion.clj
@@ -43,6 +43,18 @@
   (to-bson-document [^java.util.Date input]
     input)
 
+  java.time.LocalDate
+  (to-bson-document [^java.time.LocalDate input]
+    input)
+
+  java.time.LocalDateTime
+  (to-bson-document [^java.time.LocalDateTime input]
+    input)
+
+  java.time.Instant
+  (to-bson-document [^java.time.Instant input]
+    input)
+
   Ratio
   (to-bson-document [^Ratio input]
     (double input))


### PR DESCRIPTION
Add support for Java 8+ time objects in addition to java.util.Date as the same has been supported by Mongo java driver since 3.7